### PR TITLE
Include unistd.h

### DIFF
--- a/src/SaliencyDetector.cpp
+++ b/src/SaliencyDetector.cpp
@@ -7,6 +7,7 @@
 //============================================================================
 
 
+#include <unistd.h>
 #include <iostream>
 #include <stdlib.h>
 #include <string>


### PR DESCRIPTION
## Description

Includes `unistd` in the `SaliencyDetector.cpp` file.
## Explanation

In order for this to compile under Debian using g++ version `g++ (Debian 4.7.2-5) 4.7.2` I had to add `unistd.h` to the `src/SaliencyDetector.cpp` otherwise the `access` function and its constants (`F_OK`, here) were not defined.

I'm not a C or a C++ guy generally so this may not be appropriate for a merge but it worked for me.
